### PR TITLE
Update server.es.yml

### DIFF
--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -21,27 +21,62 @@ es:
         
     dice:
       not_enough_dice: |-
-        Yo lo siento mucho :crying_cat_face: Mis programadores solo me dieron %{num_of_dice} dados para jugar.
+        Solo tengo %{num_of_dice} dados para jugar. Es vergonsozo lo sé!
       out_of_range: |-
         ¿Sabías que el máximo número de lados para que un dado, matemáticamente correcto, es de 120 lados?
-        https://www.wired.com/2016/05/mathematical-challenge-of-designing-the-worlds-most-complex-120-sided-dice
+        
       results: |-
         > :game_die: tirada de dados: %{results}
+
+    quote:
+      "1":
+        quote: "In the middle of every difficulty lies opportunity"
+        author: "Albert Einstein"
+      "2":
+        quote: "You must be the change you wish to see in the world."
+        author: "Mahatma Gandhi"
+      "3":
+        quote: "Don’t cry because it’s over, smile because it happened."
+        author: "Dr Suess"
+      "4":
+        quote: "If you want something done right, do it yourself."
+        author: "Charles-Guillaume Étienne"
+      "5":
+        quote: "Believe you can and you’re halfway there."
+        author: "Theodore Roosevelt"
+      "6":
+        quote: "Life is like a box of chocolates. You never know what you’re gonna get."
+        author: "Forrest Gump’s Mom"
+      "7":
+        quote: "That’s one small step for a man, a giant leap for mankind."
+        author: Neil Armstrong
+      "8":
+        quote: "Do one thing every day that scares you."
+        author: "Eleanor Roosevelt"
+      "9":
+        quote: "Mistakes are always forgivable, if one has the courage to admit them."
+        author:
+      "10":
+        quote: 'Whatever the mind of man can conceive and believe, it can achieve.'
+        author: 'Napoleon Hill'
+      results: |-
+        > :left_speech_bubble: _%{quote}_ &mdash; %{author}
+
 
     track_selector:
       random_mention:
         dice: |-
-          :game_die: tirada de dados: %{results}
+          :game_die: %{results}
         quote: |-
           > :left_speech_bubble: _%{quote}_ &mdash; %{author}
         tracks: |-
           Hola! Estoy conociendo cómo hacer las siguientes cosas:
 
           `@%{discobot_username} %{reset_trigger} %{default_track}`
-          > Starts one of the following interactive narratives: %{tracks}.
+          > Inicia una de las siguientes narraciones interactivas: %{tracks}.
         bot_actions: |-
           `@%{discobot_username} roll 2d6`
-          > :game_die: tirada de dados: 3, 6
+          > :game_die: 3, 6
 
           `@%{discobot_username} quote`
           > :left_speech_bubble: _Carry out a random act of kindness, with no expectation of reward, safe in the knowledge that one day someone might do the same for you_ &mdash; Princess Diana
@@ -144,7 +179,7 @@ es:
           Oh oh, no veo ningún mensaje marcado como favorito en esta conversación. No encontraste cómo marcar el mensaje debajo del post? Prueba usando el "ver más" <img src="/images/font-awesome-ellipsis.png" width="16" height="16"> para ver las opciones, y ahí está el botón del marcador.
       emoji:
         instructions: |-
-          Habrás notado que uso algunas imagenes pequeñas en mis respuestas por ejemplo: :blue_car::dash: éstos son denominados [emoji](https://en.wikipedia.org/wiki/Emoji). ¿Puedes **agregar un emoji** a tu respuesta? Cualquiera de éstos funcionarán:
+          Habrás notado que uso algunas imagenes pequeñas en mis respuestas por ejemplo: :blue_car::dash: éstos son denominados [emoji](https://es.wikipedia.org/wiki/Emoji). ¿Puedes **agregar un emoji** a tu respuesta? Cualquiera de éstos funcionarán:
 
           - Escribe `:) ;) :D :P :O`
 
@@ -193,7 +228,7 @@ es:
 
           <img src="/images/capybara-eating.gif"/>
 
-          ¿Te fijaste en que estás de vuelta al principio? Alimenta este pobre hambriendo capybara **respondiendo con el emoji `:herb:` ** y serás automáticamente enviado al final.
+          ¿Te fijaste en que estás de vuelta al principio? Alimenta este pobre hambriendo capybara **respondiendo con el emoji :herb:** y serás automáticamente enviado al final.
         reply: |-
           Yay lo encontraste! :tada:
 

--- a/config/locales/server.es.yml
+++ b/config/locales/server.es.yml
@@ -228,7 +228,7 @@ es:
 
           <img src="/images/capybara-eating.gif"/>
 
-          ¿Te fijaste en que estás de vuelta al principio? Alimenta este pobre hambriendo capybara **respondiendo con el emoji :herb:** y serás automáticamente enviado al final.
+          ¿Te fijaste en que estás de vuelta al principio? Alimenta este pobre hambriendo capybara **respondiendo con el emoji `:herb:`** y serás automáticamente enviado al final.
         reply: |-
           Yay lo encontraste! :tada:
 


### PR DESCRIPTION
Updating:

* https://github.com/discourse/discourse-narrative-bot/commit/476fbe0bf386c96b3afa308f5f1cd55869ce6979
* https://github.com/discourse/discourse-narrative-bot/commit/ac5ba4d2506303153dc7ca58cb38eb1008c55e3c
Here I did not put the link in english. 
* https://github.com/discourse/discourse-narrative-bot/commit/ad1361f423a9fc705646608154bdaa09c9bc9d04#diff-aeb8651199334c1cb831e884ff85773a
I added the english quotes non translated. 

New changes:

* I changed Emoji Wikipedia link with https://es.wikipedia.org/wiki/Emoji (spanish link from Wikipedia).
* I changed markdown error at line 231
* No translated text, line: 76 (now it's translated)